### PR TITLE
Add a .bowerrc file and explicitly specify the bower install folder

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
The applications assumes that the bower components will be in the default location "bower_components", but this depends on the local configuration. For example in my case the default location is "app/bower_components", causing problems if I "build" with "bower install".

This PR adds a .bowerrc local configuration file for the project that sets the bower components folder explicitly.
